### PR TITLE
bl616_tn20k

### DIFF
--- a/build_tn20k_bl616.tcl
+++ b/build_tn20k_bl616.tcl
@@ -91,7 +91,7 @@ set_option -use_mspi_as_gpio 1
 set_option -use_sspi_as_gpio 1
 set_option -use_done_as_gpio 1
 set_option -use_ready_as_gpio 1
-set_option -use_jtag_as_gpio 1
+set_option -use_jtag_as_gpio 0
 set_option -print_all_synthesis_warning 1
 set_option -rw_check_on_ram 0
 set_option -user_code 00000001

--- a/impl/nanoapple2_tn20k_bl616_process_config.json
+++ b/impl/nanoapple2_tn20k_bl616_process_config.json
@@ -39,7 +39,7 @@
  ],
  "Incremental_Compile" : "",
  "Initialize_Primitives" : false,
- "JTAG" : true,
+ "JTAG" : false,
  "MODE_IO" : false,
  "MSPI" : true,
  "MSPI_JUMP" : false,

--- a/src/tang/nano20k_bl616/nanoapple2.cst
+++ b/src/tang/nano20k_bl616/nanoapple2.cst
@@ -6,9 +6,9 @@ IO_PORT "uart_ext_tx" PULL_MODE=NONE IO_TYPE=LVCMOS33;
 
 // UART through USB-C port
 IO_LOC "uart_rx" 70;
-IO_LOC "uart_tx" 69;
+//IO_LOC "uart_tx" 69;
 IO_PORT "uart_rx" IO_TYPE=LVCMOS33;
-IO_PORT "uart_tx" IO_TYPE=LVCMOS33;
+//IO_PORT "uart_tx" IO_TYPE=LVCMOS33;
 
 IO_LOC "tmds_d_p[2]" 39,40;
 IO_PORT "tmds_d_p[2]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
@@ -69,7 +69,7 @@ IO_LOC "spi_dat" 76;
 IO_PORT "spi_dat" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "spi_dir" 75;
 IO_PORT "spi_dir" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
-IO_LOC "spi_irqn" 8; // TDO
+IO_LOC "spi_irqn" 69; // UART TX output
 IO_PORT "spi_irqn" PULL_MODE=NONE DRIVE=8 IO_TYPE=LVCMOS33;
 
 // generic IO pins to use for e.g. db9 joystick

--- a/src/tang/nano20k_bl616/nanoapple2.vhd
+++ b/src/tang/nano20k_bl616/nanoapple2.vhd
@@ -35,7 +35,7 @@ entity nanoapple2 is
     leds_n      : out std_logic_vector(5 downto 0);
     -- onboard USB-C Tang BL616 UART
     uart_rx     : in std_logic;
-    uart_tx     : out std_logic;
+--uart_tx     : out std_logic;
     -- external hw pin UART
     uart_ext_rx : in std_logic;
     uart_ext_tx : out std_logic;
@@ -85,6 +85,7 @@ end nanoapple2;
 
 architecture datapath of nanoapple2 is
 
+signal uart_tx : std_logic;
 signal clk_sys : std_logic;
 signal clk_core : std_logic;
 signal clk_pixel_x5 : std_logic;


### PR DESCRIPTION
Optimized SPI Interface pin use to keep FPGA programming active all the time.